### PR TITLE
Fix birthday notification generation for empty sections

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,18 +15,20 @@ export const generateBirthdayMessage = (data: EventsMap): string => {
     };
 
     let message = '🎉 Напоминаю о ближайших днях рождения:\n\n';
+    let hasEvents = false;
 
     for (const [title, events] of Object.entries(sections)) {
         if (events.length === 0) {
-            message = '';
-        } else {
-            message += `${title}:\n`;
-            events.forEach((event) => {
-                message += `- ${event.date} ${event.summary}\n`;
-            });
-            message += '\n'; // Добавляем пустую строку между секциями
+            continue;
         }
+
+        hasEvents = true;
+        message += `${title}:\n`;
+        events.forEach((event) => {
+            message += `- ${event.date} ${event.summary}\n`;
+        });
+        message += '\n'; // Добавляем пустую строку между секциями
     }
 
-    return message.trim();
+    return hasEvents ? message.trim() : '';
 };


### PR DESCRIPTION
## Summary
- avoid resetting message when a section has no birthdays
- skip empty sections and return an empty string only when there are no events

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bab1ea6274832b84f614bea0c58738